### PR TITLE
Clean up internals and make workers optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,57 @@ Havanna
 
 Ruby workers with [Disque][disque].
 
+
 Usage
 -----
 
-Create a worker:
+Similar to Rack's `config.ru`, Havanna has an entry point file where you
+explicitly declare handlers for your queues.
+The minimum you need to use Havanna is to create a `Havannafile`:
+
+```
+require "app"
+
+Havanna.run(Hello: -> job {
+  puts("Hello, #{job}")
+})
+```
+
+Now on the command line, start Havanna:
+
+```
+$ havanna start
+```
+
+In a different window, try queuing a job using Disque's built-in client:
+
+```
+$ disque addjob Hello world 5000
+```
+
+As expected, you should see the string "Hello, world" in the terminal where you
+started Havanna.
+
+
+Workers
+-------
+
+If you prefer to use classes to model your workers, there's `Havanna::Worker`.
+For instance, this could be `workers/mailer.rb`:
 
 ```ruby
-class Mailer
+require "havanna/worker"
+
+class Mailer < Havanna::Worker
   def call(item)
-    puts "Emailing #{item}..."
+    puts("Emailing #{item}...")
 
     # Actually do it.
   end
 end
 ```
 
-Havanna doesn't perform any kind of magic autodiscovery of
-your workers. Similar to Rack's `config.ru`, Havanna has an
-entry point file where you explicitly declare your workers.
-This would be a valid `Havannafile`:
+Then your `Havannafile` would look like this:
 
 ```ruby
 require "app"
@@ -29,21 +61,11 @@ require "app"
 Havanna.run(Mailer)
 ```
 
-Now on the command line, start your workers:
 
-```
-$ havanna start
-```
+Administration
+--------------
 
-In a different window, try queuing a job using Disque's
-built-in client:
-
-```
-$ disque addjob Mailer foo@example.com 5000
-```
-
-Once you're up and running, deploy your workers with `-d`
-for daemonization:
+Once you're up and running, deploy your workers with `-d` for daemonization:
 
 ```
 $ havanna start -d

--- a/bin/havanna
+++ b/bin/havanna
@@ -104,7 +104,7 @@ when "start"
     accum.concat(Array.new(threads_per_worker) do
       Thread.new(worker) do |worker|
         Thread.current.abort_on_exception = true
-        Havanna.start(worker)
+        Havanna.start(*worker.to_h.to_a.first)
       end
     end)
   end

--- a/lib/havanna.rb
+++ b/lib/havanna.rb
@@ -8,17 +8,15 @@ module Havanna
     @disque = Disque.new(*args)
   end
 
-  def self.start(worker)
-    instance = worker.new
-
+  def self.start(name, handler)
     begin
       disque = Disque.new(*@connect)
 
-      printf("Started worker %s\n", worker)
+      printf("Started worker %s\n", name)
 
       loop do
-        disque.fetch(from: [worker.name], timeout: 5000) do |job|
-          instance.call(job)
+        disque.fetch(from: [name], timeout: 5000) do |job|
+          handler.call(job)
         end
 
         break if @stop

--- a/lib/havanna/worker.rb
+++ b/lib/havanna/worker.rb
@@ -1,0 +1,7 @@
+module Havanna
+  class Worker
+    def self.to_h
+      {name => new.method(:call)}
+    end
+  end
+end

--- a/test/workers/echo/Havannafile
+++ b/test/workers/echo/Havannafile
@@ -1,3 +1,5 @@
-require_relative "echo"
+Havanna.connect("127.0.0.1:7711")
 
-Havanna.run(Echo)
+Havanna.run(Echo: -> job {
+  Havanna.push("Echo:result", job, 5000)
+})

--- a/test/workers/echo/echo.rb
+++ b/test/workers/echo/echo.rb
@@ -1,7 +1,0 @@
-Havanna.connect("127.0.0.1:7711")
-
-class Echo
-  def call(job)
-    Havanna.push("Echo:result", job, 5000)
-  end
-end

--- a/test/workers/logger/logger.rb
+++ b/test/workers/logger/logger.rb
@@ -1,6 +1,8 @@
 Havanna.connect("127.0.0.1:7711")
 
-class Logger
+require "havanna/worker"
+
+class Logger < Havanna::Worker
   def call(id)
     $stdout.puts("out: #{id}")
     $stderr.puts("err: #{id}")

--- a/test/workers/slow/slow.rb
+++ b/test/workers/slow/slow.rb
@@ -1,6 +1,8 @@
 Havanna.connect("127.0.0.1:7711")
 
-class Slow
+require "havanna/worker"
+
+class Slow < Havanna::Worker
   def call(n)
     sleep(n.to_i)
     Havanna.push("Slow:result", n, 5000)


### PR DESCRIPTION
This pull request makes `Havanna.run` take a hash (or something that responds to `#to_h`):

``` ruby
Havanna.run(Mailer: -> email {
  Malone.deliver(email)
})
```

This is now the most minimal way of running background jobs with Havanna. The hash key is the name of the queue to consume and the value is the proc that will process items.

Most of us will need something slightly more complex. For that we have `Havanna::Worker`:

``` ruby
# workers/mailer.rb

class Mailer < Havanna::Worker
  def call(email)
    Malone.deliver(email)
  end
end

# Havannafile

Havanna.run(Mailer)
```

You can call `Havanna.run(Mailer)` because `Havanna::Worker` implements `#to_h`.

Open questions:
- Should the method for processing items be `Havanna::Worker#process`? That way, `#call` is reserved if `Havanna::Worker` ever needs to add more functionality on top of the processing (e.g. middleware, error handling, etc.)
